### PR TITLE
1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.zip
+.vscode/*

--- a/blocks/document_library/templates/majorca_document_library/view.php
+++ b/blocks/document_library/templates/majorca_document_library/view.php
@@ -141,7 +141,7 @@ if (isset($breadcrumbs) && $breadcrumbs) { ?>
     </div>
 
     <?php if (isset($pagination)) { ?>
-        <?//=$pagination?>
+        <?php//=$pagination?>
         <?php
 			$pagination = $list->getPagination();
 			if ($pagination->getTotalPages() > 1) {

--- a/blocks/majorca_slick_slider/form.php
+++ b/blocks/majorca_slick_slider/form.php
@@ -266,7 +266,9 @@ echo $app->make('helper/concrete/ui')->tabs($tabs);
     }
 </style>
 
-<div id="ccm-tab-content-slides-<?php echo $getString?>" class="ccm-tab-content">
+<div class="tab-content">
+
+<div id="<?php echo $tabs[0][0]?>" class="tab-pane active" role="tabpanel">
     <div class="ccm-image-slider-block-container">
         <div class="ccm-image-slider-entries ccm-image-slider-entries-<?php echo $bID?>">
 
@@ -277,7 +279,7 @@ echo $app->make('helper/concrete/ui')->tabs($tabs);
     </div>
 </div>
 
-<div id="ccm-tab-content-options-<?php echo $getString?>" class="ccm-tab-content">
+<div id="<?php echo $tabs[1][0]?>" class="tab-pane" role="tabpanel">
     <label class="control-label"><?php echo t('Navigation'); ?></label>
     <div class="form-group">
         <div class="radio">
@@ -382,6 +384,8 @@ Max 4 for Carousel Slider.')); ?>
             </label>
         </div>
     </div>
+
+</div>
 
 </div>
 

--- a/blocks/majorca_testimonial_carousel/form.php
+++ b/blocks/majorca_testimonial_carousel/form.php
@@ -283,6 +283,9 @@ $id = $controller->getIdentifier();
     }
 </style>
 
+<div class="tab-content">
+
+<div id="<?php echo $tabs[0][0]?>" class="tab-pane active" role="tabpanel">
 <div id="ccm-tab-content-slides-<?php echo $getString?>" class="ccm-tab-content">
     <div class="majorca-testimonial-carousel-block-container">
         <div class="majorca-testimonial-carousel-entries majorca-testimonial-carousel-entries-<?php echo $bID?>">
@@ -294,7 +297,7 @@ $id = $controller->getIdentifier();
     </div>
 </div>
 
-<div id="ccm-tab-content-options-<?php echo $getString?>" class="ccm-tab-content">
+<div id="<?php echo $tabs[1][0]?>" class="tab-pane" role="tabpanel">
     <label class="control-label"><?php echo t('Navigation'); ?></label>
     <div class="form-group">
         <div class="radio">
@@ -361,6 +364,8 @@ $id = $controller->getIdentifier();
         <?php echo $form->number($view->field('slidesToShow'), $slidesToShow ? $slidesToShow : 3, array('min' => '1', 'max' => '4'))?>
         </div>
     </div>
+</div>
+
 </div>
 
 <script type="text/template" id="testimonialCarouselTemplate-<?php echo $bID?>">

--- a/blocks/majorca_topic_page_list/page_list_form.php
+++ b/blocks/majorca_topic_page_list/page_list_form.php
@@ -22,10 +22,10 @@ $form = $app->make('helper/form/page_selector');
     //array('page-list-preview', t('Preview'))
 ));?>
 
-<div class="ccm-tab-content" id="ccm-tab-content-page-list-settings">
-    <div class=" pagelist-form">
+<div class="tab-content">
+<div class="tab-pane active pagelist-form" id="page-list-settings" role="tabpanel">
 
-        <input type="hidden" name="pageListToolsDir" value="<?php echo $app->make('helper/concrete/urls')->getBlockTypeToolsURL($bt) ?>/"/>
+        <input type="hidden" name="pageListToolsDir" value="<?php echo $app->make('helper/concrete/urls')->getBlockTypeAssetsURL($bt) ?>/"/>
 
         <fieldset>
 <!---------------------------------------------------------------------------->
@@ -612,7 +612,6 @@ $form = $app->make('helper/form/page_selector');
         var treeViewTemplate = $('.tree-view-template');
 
         $('select[name=customTopicAttributeKeyHandle]').on('change', function() {
-            var toolsURL = '<?php echo $app->make('helper/concrete/urls')->getToolsURL('tree/load'); ?>';
             var chosenTree = $(this).find('option:selected').attr('data-topic-tree-id');
             $('.tree-view-template').remove();
             if (!chosenTree) {

--- a/controller.php
+++ b/controller.php
@@ -14,8 +14,8 @@ class Controller extends Package
 {
 
 	protected $pkgHandle = 'theme_majorca';
-	protected $appVersionRequired = '8.0.0';
-	protected $pkgVersion = '1.0.2';
+	protected $appVersionRequired = '9.0.0';
+	protected $pkgVersion = '1.1.0';
 	protected $pkgAllowsFullContentSwap = true;
 
 	public function getPackageDescription()
@@ -114,9 +114,11 @@ class Controller extends Package
 
         //install or upgrade ThumbnailType
         $thumbnailTypes = array(
-                            array('name' => 'Small','handle' => 'small', 'width' => 740),
-                            array('name' => 'Medium','handle' => 'medium', 'width' => 940),
-                            array('name' => 'Large','handle' => 'large', 'width' => 1140),
+                            array('name' => 'XSmall','handle' => 'xsmall', 'width' => 450),
+                            array('name' => 'Small','handle' => 'small', 'width' => 800),
+                            array('name' => 'Medium','handle' => 'medium', 'width' => 1000),
+                            array('name' => 'Large','handle' => 'large', 'width' => 1400),
+                            array('name' => 'XLarge','handle' => 'xlarge', 'width' => 2000),
                          );
         foreach($thumbnailTypes as $tt){
 		    $em = $this->app->make('Doctrine\ORM\EntityManagerInterface');

--- a/themes/majorca/css/build/slick.less
+++ b/themes/majorca/css/build/slick.less
@@ -120,7 +120,7 @@
 
 
 
-@charset 'UTF-8';
+@charset "UTF-8";
 /* Slider */
 .slick-loading .slick-list
 {
@@ -410,13 +410,13 @@
 
 	@media (min-width: 480px) {
 
-		.slick-prev,
-		.slick-next,
-		[dir='rtl'] .slick-prev,
-		[dir='rtl'] .slick-next {
+//		.slick-prev,
+//		.slick-next,
+//		[dir='rtl'] .slick-prev,
+//		[dir='rtl'] .slick-next {
 // 		    display: inline-block;
 // 		    display: inline-block !important;
-		}
+//		}
 
 		.slick-prev {
 	    	left: 0;
@@ -509,7 +509,7 @@
 			img {
 				max-width: 200%;
 				width: 200%;
-				height: 100%;
+				height: auto;
 				position: absolute;
 				top: 50%;
 				left: 50%;

--- a/themes/majorca/css/main.less
+++ b/themes/majorca/css/main.less
@@ -344,3 +344,5 @@ div.ccm-page {
 }
 
 #concrete-announcement-modal { opacity: 1; }
+
+div.image-noscale img {width:auto;}


### PR DESCRIPTION
Fixes to version 2.0.0/1.0.2

- fix block form.php div class for slider and testimonial carousel to tabs work
- fix from issue #4
- added image-noscale class to allow images have own original size
- controller version bump, but also added XS and XL sizes, and all sizes rounded up to have little more sharp images (i use/prefer for large 1400 and for xlarge 2000)